### PR TITLE
feat(release): explicit tag vs branch name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,4 +67,4 @@ workflows:
           filters:
             branches:
               only:
-                - /\Av[0-9]\.[0-9]\.[0-9]/
+                - /\Arelease\/v[0-9]\.[0-9]\.[0-9]/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ We do not support the full API provided by this library. We currently make the f
 
 ## Releasing
 
-- create a branch named: vX.X.X
+- create a branch named: release/vX.X.X
 - CI will build the various libraries for macos/arm64, linux/arm64, linux/x86 and commit them to the branch
-- Once the libraries have committed, tag the branch with the same name
+- Once the libraries have committed, tag the branch with the version number eg. vX.X.X


### PR DESCRIPTION
## Which problem is this PR solving?

We need to be explicit about branch vs tag names. Use a prefix of `release/` for the branch name

## Short description of the changes

Update readme and circle ci build config to specify the branch name differently to the tag name.
