### PR TITLE
feat: make archive.SymCaches public

### DIFF
--- a/dsym_archive.go
+++ b/dsym_archive.go
@@ -14,11 +14,11 @@ import (
 // Archive represents a potential multi arch object archive (like a dSYM)
 type Archive struct {
 	archive *C.SymbolicArchive
-	symCaches map[string]*SymCache
+	SymCaches map[string]*SymCache
 }
 
 func (a *Archive) buildSymCaches() error {
-	a.symCaches = make(map[string]*SymCache)
+	a.SymCaches = make(map[string]*SymCache)
 	objects, err := a.objects()
 	if (err != nil) {
 		return err
@@ -30,7 +30,7 @@ func (a *Archive) buildSymCaches() error {
 			return err
 		}
 
-		a.symCaches[symCache.debugId] = symCache
+		a.SymCaches[symCache.debugId] = symCache
 	}
 
 	return nil

--- a/dsym_symbolicator.go
+++ b/dsym_symbolicator.go
@@ -46,7 +46,7 @@ func (symbolicator *DSYMSymbolicator) SymbolicateFrame(frame *Frame, thread *Thr
 	imageIndex := frame.ImageIndex
 	image := symbolicator.Report.UsedImages[imageIndex]
 
-	cache := symbolicator.Archive.symCaches[image.UUID]
+	cache := symbolicator.Archive.SymCaches[image.UUID]
 
 	ipRegName, err := archIPRegName(cache.arch)
 	if err != nil {

--- a/dsym_test.go
+++ b/dsym_test.go
@@ -193,7 +193,7 @@ func TestFindBestInstruction(t *testing.T) {
 	imageIndex := frame1.ImageIndex
 	image := report.UsedImages[imageIndex]
 
-	cache := archive.symCaches[image.UUID]
+	cache := archive.SymCaches[image.UUID]
 
 	ipRegName, err := archIPRegName(cache.arch)
 	assert.NoError(t, err)
@@ -213,7 +213,7 @@ func TestFindBestInstruction(t *testing.T) {
 	imageIndex = frame2.ImageIndex
 	image = report.UsedImages[imageIndex]
 
-	cache = archive.symCaches[image.UUID]
+	cache = archive.SymCaches[image.UUID]
 
 	ipRegName, err = archIPRegName(cache.arch)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Which problem is this PR solving?
`archive.SymCaches` needs to be public for the collector plugin to use

see: https://github.com/honeycombio/opentelemetry-collector-symbolicator/pull/53

## Short description of the changes
Make `archiveSymCaches` public

## How to verify that this has the expected result
- [x] tests pass