### PR TITLE
rel: prep for 0.0.4

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,8 @@ Please see our [OSS process document](https://github.com/honeycombio/home/blob/m
 ## Short description of the changes
 
 ## How to verify that this has the expected result
+
+---
+
+- [ ] CHANGELOG is updated
+- [ ] README is updated with documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,16 @@
-# {project-name} changelog
+# symbolic-go changelog
 
+## 0.0.4
+### Enhancements
+- update dsym support: expose `SymCaches` field on dSYM `Archive`
+
+## 0.0.3
+### Enhancements
+- add dsym support
+- add proguard support
+
+### Maintenance
+- use forks of `symbolic` and `source-map-tests` submodules instead of upstream
+
+## 0.0.2
+- initial release


### PR DESCRIPTION
## Which problem is this PR solving?
We forgot to update our `CHANGELOG.md`.

Once this is merged, I'll tag + release `0.0.4`. 

## Short description of the changes
- Retroactively update the changelog
    - I didn't see a `0.0.1` tag or release so our changelog starts with `0.0.2`
- Add prompts to our pull request template to ensure we continue to update the changelog in the future.

## How to verify that this has the expected result
Changelog is accurate to our commits and changes.