### PR TITLE
fix: clean up memory management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 # symbolic-go changelog
 
+## Unreleased
+### Maintenance
+- Fix segfaults when calling `Symcache.Lookup()`
+
+## 0.0.6
+### Maintenance
+- Fix build error in 0.0.5 and 0.0.4
+
 ## 0.0.5
-### Maintenance 
+### Maintenance
 - Fix build error in 0.0.4
 
 ## 0.0.4

--- a/dsym_archive_symcache.go
+++ b/dsym_archive_symcache.go
@@ -29,14 +29,15 @@ type SourceLocation struct {
 
 func (s *SymCache) Lookup(addr uint64) ([]SourceLocation, error) {
 	C.symbolic_err_clear()
+
 	result := C.symbolic_symcache_lookup(s.symcache, C.uint64_t(addr))
-	defer C.symbolic_lookup_result_free(&result)
 
 	err := checkErr()
-
 	if err != nil {
 		return nil, err
 	}
+
+	defer C.symbolic_lookup_result_free(&result)
 
 	if result.items == nil || result.len == 0 {
 		return []SourceLocation{}, nil
@@ -111,7 +112,6 @@ func NewSymCacheFromObject(object *Object) (*SymCache, error) {
 	err := checkErr()
 
 	if err != nil {
-		C.symbolic_symcache_free(sc)
 		return nil, err
 	}
 

--- a/dsym_symbolicator.go
+++ b/dsym_symbolicator.go
@@ -8,7 +8,6 @@ package symbolic
 import "C"
 import (
 	"strings"
-	"unsafe"
 )
 
 type Frame struct {
@@ -85,8 +84,9 @@ func (symbolicator *DSYMSymbolicator) SymbolicateFrame(frame *Frame, thread *Thr
 }
 
 func findBestInstruction(addr, ipRegValue uint64, signal uint32, arch string, crashingFrame bool) (uint64, error) {
-	sii := (*C.SymbolicInstructionInfo)(C.malloc(C.sizeof_SymbolicInstructionInfo))
-	defer C.free(unsafe.Pointer(sii))
+	siiptr := C.malloc(C.sizeof_SymbolicInstructionInfo)
+	sii := (*C.SymbolicInstructionInfo)(siiptr)
+	defer C.free(siiptr)
 
 	sii.addr = C.uint64_t(addr) 
 	sii.arch = encodeStr(arch)


### PR DESCRIPTION
## Which problem is this PR solving?
tests on https://github.com/honeycombio/opentelemetry-collector-symbolicator/pull/53 were failing

## Short description of the changes
- point all `runtime.SetFinalizer` calls at go objects, not structs returned from the `symbolic` ffi. 
- avoid using `unsafe.Slice` when processing results returned as an array
  - I don't have a good explanation for this other than observing that the `unsafe.Slice` call would end up copying some objects that shouldn't be copied, which led to things getting `free`'d twice, which led to segfaults. 

## How to verify that this has the expected result
- [x] tests pass

---

- [x] CHANGELOG is updated
- [ ] ~README is updated with documentation~
