### PR TITLE
feat: unsafe slice removal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module github.com/honeycombio/symbolic-go
 
 go 1.21.3
 
-require (
-	github.com/google/uuid v1.6.0
-	github.com/stretchr/testify v1.10.0
-)
+require github.com/stretchr/testify v1.10.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/proguard.go
+++ b/proguard.go
@@ -80,6 +80,8 @@ func (p *ProguardMapper) RemapFrame(class, method string, line int) ([]*Symbolic
 
 	frames := toSymbolicJavaStackFrames(&s)
 
+	C.symbolic_proguardmapper_result_free(&s)
+
 	return frames, nil
 }
 
@@ -110,6 +112,8 @@ func (p *ProguardMapper) RemapMethod(class, method string) ([]*SymbolicJavaStack
 	}
 
 	r := toSymbolicJavaStackFrames(&s)
+
+	C.symbolic_proguardmapper_result_free(&s)
 
 	return r, nil
 }

--- a/proguard.go
+++ b/proguard.go
@@ -133,14 +133,18 @@ type SymbolicJavaStackFrame struct {
 func toSymbolicJavaStackFrames(s *C.SymbolicProguardRemapResult) []*SymbolicJavaStackFrame {
 	frames := make([]*SymbolicJavaStackFrame, s.len)
 
-	for i, s := range unsafe.Slice(s.frames, s.len) {
+	ptr := unsafe.Pointer(s.frames)
+
+	for i := 0; i < int(s.len); i++ {
+		frame := (*C.SymbolicJavaStackFrame)(ptr)
 		frames[i] = &SymbolicJavaStackFrame{
-			ClassName:      decodeStr(&s.class_name),
-			MethodName:     decodeStr(&s.method),
-			LineNumber:     int(s.line),
-			SourceFile:     decodeStr(&s.file),
-			ParameterNames: decodeStr(&s.parameters),
+			ClassName:      decodeStr(&frame.class_name),
+			MethodName:     decodeStr(&frame.method),
+			LineNumber:     int(frame.line),
+			SourceFile:     decodeStr(&frame.file),
+			ParameterNames: decodeStr(&frame.parameters),
 		}
+		ptr = unsafe.Add(ptr, C.sizeof_SymbolicJavaStackFrame)
 	}
 
 	return frames

--- a/proguard_test.go
+++ b/proguard_test.go
@@ -11,7 +11,7 @@ func TestProguard(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.True(t, pm.HasLineInfo)
-	assert.Equal(t, "a48ca62b-df26-544e-a8b9-2a5ce210d1d5", pm.UUID.String())
+	assert.Equal(t, "a48ca62b-df26-544e-a8b9-2a5ce210d1d5", pm.UUID)
 
 	class, err := pm.RemapClass("android.support.constraint.ConstraintLayout$a")
 	assert.NoError(t, err)


### PR DESCRIPTION
## Short description of the changes

As per #19 we were using `unsafe.slice` incorrectly. This removes the usage of it in line with what #19 is doing.

- removes the UUID dependency as we dont need it
- correctly frees the proguard mapper results

- [ ] CHANGELOG is updated
- [ ] README is updated with documentation
