### PR TITLE
feat: expose Swift demangling on dsym

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # symbolic-go changelog
 
 ## Unreleased
+### Enhancements
+- feat: expose Swift demangling on dsym
+
 ### Maintenance
 - Fix segfaults when calling `Symcache.Lookup()`
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ We do not support the full API provided by this library. We currently make the f
 * symbolic_archive_get_object
 * symbolic_archive_object_count
 * symbolic_archive_open
+* symbolic_demangle
 * symbolic_err_get_backtrace
 * symbolic_err_get_last_code
 * symbolic_err_get_last_message

--- a/dsym_symbolicator.go
+++ b/dsym_symbolicator.go
@@ -85,9 +85,9 @@ func (symbolicator *DSYMSymbolicator) SymbolicateFrame(frame *Frame, thread *Thr
 	return res, nil
 }
 
+var langSymbolicStr = encodeStr("Swift")
 func demangle(symbol string) string {
 	symbolSymbolicStr := encodeStr(symbol)
-	langSymbolicStr := encodeStr("Swift")
 
 	demangledSymbol := C.symbolic_demangle(symbolSymbolicStr, langSymbolicStr)
 

--- a/dsym_symbolicator.go
+++ b/dsym_symbolicator.go
@@ -72,6 +72,8 @@ func (symbolicator *DSYMSymbolicator) SymbolicateFrame(frame *Frame, thread *Thr
 		symbol := strings.Clone(loc.Symbol)
 		symAddr := loc.SymAddr
 
+		symbol = demangle(symbol)
+
 		res[idx] = Frame{
 			Symbol: &symbol,
 			SymbolLocation: &symAddr,
@@ -81,6 +83,15 @@ func (symbolicator *DSYMSymbolicator) SymbolicateFrame(frame *Frame, thread *Thr
 	}
 
 	return res, nil
+}
+
+func demangle(symbol string) string {
+	symbolSymbolicStr := encodeStr(symbol)
+	langSymbolicStr := encodeStr("Swift")
+
+	demangledSymbol := C.symbolic_demangle(symbolSymbolicStr, langSymbolicStr)
+
+	return decodeStr(&demangledSymbol)
 }
 
 func findBestInstruction(addr, ipRegValue uint64, signal uint32, arch string, crashingFrame bool) (uint64, error) {

--- a/dsym_test.go
+++ b/dsym_test.go
@@ -159,7 +159,7 @@ func TestSymbolicateWithDSym(t *testing.T) {
 	assert.Equal(t, "Swift runtime failure: Unexpectedly found nil while unwrapping an Optional value", *sframe1.Symbol)
 	assert.Equal(t, uint64(4294967295), *sframe1.SymbolLocation)
 	sframe2 := symbolicated[1]
-	assert.Equal(t, "$s15crashcrashcrash4loopyyF", *sframe2.Symbol)
+	assert.Equal(t, "crashcrashcrash.loop() -> ()", *sframe2.Symbol)
 	assert.Equal(t, uint64(4084), *sframe2.SymbolLocation)
 	
 	// frame 2 symbolicates to just 1
@@ -168,7 +168,7 @@ func TestSymbolicateWithDSym(t *testing.T) {
 	assert.Len(t, symbolicated, 1)
 	
 	sframe1 = symbolicated[0]
-	assert.Equal(t, "$s15crashcrashcrash11crashTheAppyyF", *sframe1.Symbol)
+	assert.Equal(t, "crashcrashcrash.crashTheApp() -> ()", *sframe1.Symbol)
 	assert.Equal(t, uint64(4072), *sframe1.SymbolLocation)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes
Now that demangling is back in our symbolic fork's CABI, we can expose those functions in this package. Adding demangling support to Swift.

## How to verify that this has the expected result
Updated unit tests pass!

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation
