### PR TITLE
fix: Fix demangling not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # symbolic-go changelog
 
 ## Unreleased
+- fix: Fix demangling not working
 
 ## 0.0.7
 ### Enhancements

--- a/dsym_archive_symcache.go
+++ b/dsym_archive_symcache.go
@@ -68,6 +68,7 @@ func (s *SymCache) Lookup(addr uint64) ([]SourceLocation, error) {
 }
 
 var langSymbolicStr = encodeStr("Swift")
+// Tries to demangle the given symbolic string. Falls back to the original string if demangling fails.
 func demangle(symbol *C.SymbolicStr) string {
 	demangledSymbol := C.symbolic_demangle(symbol, langSymbolicStr)
 	return decodeStr(&demangledSymbol)

--- a/dsym_archive_symcache.go
+++ b/dsym_archive_symcache.go
@@ -57,7 +57,7 @@ func (s *SymCache) Lookup(addr uint64) ([]SourceLocation, error) {
 			InstrAddr: uint64(item.instr_addr),
 			Line:      uint32(item.line),
 			Lang:      decodeStr(&item.lang),
-			Symbol:    decodeStr(&item.symbol),
+			Symbol:    demangle(&item.symbol),
 			FullPath:  decodeStr(&item.full_path),
 		}
 
@@ -67,6 +67,11 @@ func (s *SymCache) Lookup(addr uint64) ([]SourceLocation, error) {
 	return sourceLocations, nil
 }
 
+var langSymbolicStr = encodeStr("Swift")
+func demangle(symbol *C.SymbolicStr) string {
+	demangledSymbol := C.symbolic_demangle(symbol, langSymbolicStr)
+	return decodeStr(&demangledSymbol)
+}
 
 func archIPRegName(arch string) (string, error) {
 	C.symbolic_err_clear()

--- a/dsym_symbolicator.go
+++ b/dsym_symbolicator.go
@@ -72,8 +72,6 @@ func (symbolicator *DSYMSymbolicator) SymbolicateFrame(frame *Frame, thread *Thr
 		symbol := strings.Clone(loc.Symbol)
 		symAddr := loc.SymAddr
 
-		symbol = demangle(symbol)
-
 		res[idx] = Frame{
 			Symbol: &symbol,
 			SymbolLocation: &symAddr,
@@ -83,15 +81,6 @@ func (symbolicator *DSYMSymbolicator) SymbolicateFrame(frame *Frame, thread *Thr
 	}
 
 	return res, nil
-}
-
-var langSymbolicStr = encodeStr("Swift")
-func demangle(symbol string) string {
-	symbolSymbolicStr := encodeStr(symbol)
-
-	demangledSymbol := C.symbolic_demangle(symbolSymbolicStr, langSymbolicStr)
-
-	return decodeStr(&demangledSymbol)
 }
 
 func findBestInstruction(addr, ipRegValue uint64, signal uint32, arch string, crashingFrame bool) (uint64, error) {


### PR DESCRIPTION
## Short description of the changes
The demangling functionality was placed in an unused file, moving it to a file we actually use!

## How to verify that this has the expected result

I tested locally with the `dsym_test.go` file we have. I just changed to lookup address to `0xFF4`.

Before:
![image](https://github.com/user-attachments/assets/ea775029-6862-4619-a470-a26f7c8704c0)

After:
![image](https://github.com/user-attachments/assets/975ad4de-bf7c-4ff9-9574-01f9fcbd7382)

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation
